### PR TITLE
Update Fedora and CentOS instructions, add openSuse instructions

### DIFF
--- a/src/wiki/installing/linux/fedora.md
+++ b/src/wiki/installing/linux/fedora.md
@@ -1,13 +1,13 @@
 ---
 eleventyNavigation:
   parent: Linux
-  key: Fedora / openSUSE
+  key: Fedora / CentOS Stream
 --- 
-# <img src="https://www.vectorlogo.zone/logos/getfedora/getfedora-icon.svg" height="20"> Fedora
+# <img src="https://www.vectorlogo.zone/logos/getfedora/getfedora-icon.svg" height="20"> Fedora & CentOS Stream
 
-An RPM package is available on [COPR](https://copr.fedorainfracloud.org/coprs/polymc/polymc/)
+An RPM package is available on [COPR](https://copr.fedorainfracloud.org/coprs/sentry/polymc/)
 
 ```
-sudo dnf copr enable polymc/polymc
+sudo dnf copr enable sentry/polymc
 sudo dnf install polymc
 ```

--- a/src/wiki/installing/linux/opensuse.md
+++ b/src/wiki/installing/linux/opensuse.md
@@ -1,0 +1,14 @@
+---
+eleventyNavigation:
+  parent: Linux
+  key: openSUSE
+--- 
+# <img src="https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg" height="20"> openSuse
+
+An RPM package is available on [COPR](https://copr.fedorainfracloud.org/coprs/sentry/polymc/)
+
+```
+. /etc/os-release
+
+curl "https://copr.fedorainfracloud.org/coprs/sentry/polymc/repo/$ID/sentry-polymc-$ID.repo" | sudo tee "/etc/zypp/repos.d/sentry-polymc-$ID.repo"
+```


### PR DESCRIPTION
changing from polymc/polymc to sentry/polymc, since the original polymc repo was maintained by Swurl.

moved openSuse instructions onto their own page, because zypper lacks copr integration