### PR TITLE
fix: load the right fonts

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -15,7 +15,9 @@
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
     <link rel="alternate" href="{{ metadata.jsonfeed.path | url }}" type="application/json" title="{{ metadata.title }}">
     <link rel="icon" type="image/png" sizes="128x128" href="{{ '/img/favicon.png' | url }}">
-    <link rel="stylesheet" type="text/css" href="{{ '/assets/fonts/inter/latin-ext.css' | url }}">
+    <link rel="stylesheet" type="text/css" href="{{ '/assets/fonts/inter/index.css' | url }}">
+    <link rel="stylesheet" type="text/css" href="{{ '/assets/fonts/inter/600.css' | url }}">
+    <link rel="stylesheet" type="text/css" href="{{ '/assets/fonts/inter/700.css' | url }}">
   </head>
   <body>
     {{ content | safe }}


### PR DESCRIPTION
Seems like `latin-ext` only contains some characters outside the `latin` character space.