### PR TITLE
Move all relevant info to polymc-gentoo

### DIFF
--- a/src/wiki/installing/linux/gentoo.md
+++ b/src/wiki/installing/linux/gentoo.md
@@ -7,23 +7,4 @@ eleventyNavigation:
 
 Gentoo ebuilds are available in the [polymc-gentoo](https://gitlab.com/flowln/polymc-gentoo) overlay, named `games-action/polymc`. If you encounter any problems with those, please open an issue on that repository first, since it is maintained by third-parties!
 
-To install PolyMC, do the following:
-```bash
-# May require root access
-
-echo "[polymc]
-location = /var/db/repos/polymc
-sync-type = git
-sync-uri = https://gitlab.com/flowln/polymc-gentoo.git" > /etc/portage/repos.conf/polymc.conf
-
-emerge --sync polymc
-
-emerge polymc
-
-# To use the latest git version:
-sudo tee -a /etc/portage/package.accept_keywords <<< "=games-action/polymc-9999 **"
-```
-
-The USE flags currently available are:
-- debug: Enable debug output, useful for development and troubleshooting
-- xrandr: Minecraft <= 1.12.2 need this to work properly (See [this issue](https://github.com/PolyMC/PolyMC/issues/227))
+There are various informations, such as install instructions and USE flag usage, [laid out on the README](https://gitlab.com/flowln/polymc-gentoo/-/blob/main/README.md). Have fun! :)

--- a/src/wiki/installing/linux/gentoo.md
+++ b/src/wiki/installing/linux/gentoo.md
@@ -7,4 +7,4 @@ eleventyNavigation:
 
 Gentoo ebuilds are available in the [polymc-gentoo](https://gitlab.com/flowln/polymc-gentoo) overlay, named `games-action/polymc`. If you encounter any problems with those, please open an issue on that repository first, since it is maintained by third-parties!
 
-There are various informations, such as install instructions and USE flag usage, [laid out on the README](https://gitlab.com/flowln/polymc-gentoo/-/blob/main/README.md). Have fun! :)
+More information, such as install instructions and USE flag usage, is [laid out in the README](https://gitlab.com/flowln/polymc-gentoo/-/blob/main/README.md). Have fun! :)


### PR DESCRIPTION
So, another Gentoo change, sorry... T_T

This time, we are moving all the overlay-specific information to the overlay itself, so as to not bother the website when we make a change anymore. With that, ~I hope~ I promise we'll stop changing this every time!