### PR TITLE
add wiki about hd2000/3000 on windows

### DIFF
--- a/src/wiki/getting-started/installing-java.md
+++ b/src/wiki/getting-started/installing-java.md
@@ -23,3 +23,14 @@ Once you have **installed** Java, PolyMC will be able to detect it during the fi
 
 If you installed Java after already completing the first time setup process, you can access and modify your Java configuration through:
 > Settings > Java > Java Runtime > Auto-detect...
+
+## A note about Intel HD 2000/3000 on Windows 10
+Since those igpus are not *officially* supported on Windows 10, with them the game is likely going to crash with any modern java binary.
+
+*For 1.16.5 or older* there's a workaround, you need to install an older java binary:
+- [this for 64bit Windows](https://files.multimc.org/downloads/jre-8u51-windows-x64.zip)
+- [this for 32bit Windows](https://files.multimc.org/downloads/jre-8u51-windows-i586.zip)
+
+After you download the required java binary for your architecture, *extract* the zip, and move the folder to your PolyMC data folder (%appdata%/PolyMC for notportable, the PolyMC folder for portable builds), you need to go to the *PolyMC java settings*, then to *browse*, then go to the folder with this particular java, click *java.exe* then *open*.
+This should fix your issue.
+Unfortunately there's no workaround for java 17 (and so newer Minecraft), so you can only downgrade your Windows or switch to Linux there.


### PR DESCRIPTION
This makes users know what to do, inspired by the multimc wiki for that.
The only issue is that links to java executables hosted on files.multimc.org, but I think they'll be fine with it since it's literally linked on their wiki