### PR TITLE
Fix url to distro-specific installs

### DIFF
--- a/src/download.md
+++ b/src/download.md
@@ -54,7 +54,7 @@ scoop install polymc</code></pre>
     <p><a class="button" href="https://flathub.org/apps/details/org.polymc.PolyMC" >Install from FlatHub</a>
     <p><a class="button" href="https://github.com/PolyMC/PolyMC/releases/download/1.1.1/PolyMC-Linux-1.1.1-x86_64.AppImage" >Download (AppImage)</a>
     <p><a class="button" href="https://github.com/PolyMC/PolyMC/releases/download/1.1.1/PolyMC-Linux-1.1.1.tar.gz" >Download (tar.gz)</a></p>
-    <p>distro specific packages can be <a href="{{ '../wiki/installing/' | url}}">found here</a></p>
+    <p>Distro-specific packages can be <a href="{{ '../wiki/installing/linux/' | url}}">found here</a>!</p>
   </div>
   <div class="card">
     <h1>BSD</h1>


### PR DESCRIPTION
Previously the URL sent you to a blank page for general installation instructions.

Also makes 'distro specific' -> 'Distro-specific' and add a ! because it looks nicer :^)