### PR TITLE
Add proper links to Matrix rooms and space

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -95,18 +95,18 @@ hero:
 
   For people who don't want to use Discord, we have a Matrix Space which is bridged to the Discord server:
 
-  ![PolyMC Space](https://img.shields.io/matrix/polymc:matrix.org?label=PolyMC%20space)
+  [![PolyMC Space](https://img.shields.io/matrix/polymc:matrix.org?label=PolyMC%20space)](https://matrix.to/#/#polymc:matrix.org)
 
   If there are any issues with the space or you are using a client that does not support the feature here are the individual rooms:
 
-  ![Development](https://img.shields.io/matrix/polymc-development:matrix.org?label=PolyMC%20Development)
-  ![Discussion](https://img.shields.io/matrix/polymc-discussion:matrix.org?label=PolyMC%20Discussion)
-  ![Github](https://img.shields.io/matrix/polymc-github:matrix.org?label=PolyMC%20Github)
-  ![Maintainers](https://img.shields.io/matrix/polymc-maintainers:matrix.org?label=PolyMC%20Maintainers)
-  ![News](https://img.shields.io/matrix/polymc-news:matrix.org?label=PolyMC%20News)
-  ![Offtopic](https://img.shields.io/matrix/polymc-offtopic:matrix.org?label=PolyMC%20Offtopic)
-  ![Support](https://img.shields.io/matrix/polymc-support:matrix.org?label=PolyMC%20Support)
-  ![Voice](https://img.shields.io/matrix/polymc-voice:matrix.org?label=PolyMC%20Voice)
+  [![Development](https://img.shields.io/matrix/polymc-development:matrix.org?label=PolyMC%20Development)](https://matrix.to/#/#polymc-development:matrix.org)
+  [![Discussion](https://img.shields.io/matrix/polymc-discussion:matrix.org?label=PolyMC%20Discussion)](https://matrix.to/#/#polymc-discussion:matrix.org)
+  [![Github](https://img.shields.io/matrix/polymc-github:matrix.org?label=PolyMC%20Github)](https://matrix.to/#/#polymc-github:matrix.org)
+  [![Maintainers](https://img.shields.io/matrix/polymc-maintainers:matrix.org?label=PolyMC%20Maintainers)](https://matrix.to/#/#polymc-maintainers:matrix.org)
+  [![News](https://img.shields.io/matrix/polymc-news:matrix.org?label=PolyMC%20News)](https://matrix.to/#/#polymc-news:matrix.org)
+  [![Offtopic](https://img.shields.io/matrix/polymc-offtopic:matrix.org?label=PolyMC%20Offtopic)](https://matrix.to/#/#polymc-offtopic:matrix.org)
+  [![Support](https://img.shields.io/matrix/polymc-support:matrix.org?label=PolyMC%20Support)](https://matrix.to/#/#polymc-support:matrix.org)
+  [![Voice](https://img.shields.io/matrix/polymc-voice:matrix.org?label=PolyMC%20Voice)](https://matrix.to/#/#polymc-voice:matrix.org)
 
   # Source code
   ---


### PR DESCRIPTION
Previously there was no indication what is the room/space address, so added links to the badges