### PR TITLE
Fix 404 error

### DIFF
--- a/src/wiki/development.md
+++ b/src/wiki/development.md
@@ -9,7 +9,7 @@ If you would like to contribute to PolyMC, you might find it useful to join our 
 
 ## Building
 
-If you want to build PolyMC yourself, check out our [Build Instructions](./builds) page for a handy guide.
+If you want to build PolyMC yourself, check out our [Build Instructions](./build-instructions) page for a handy guide.
 
 
 ## Code formatting


### PR DESCRIPTION
Fixes a 404 error for the link in https://polymc.org/wiki/development/