### PR TITLE
Update Gentoo wiki page

### DIFF
--- a/src/wiki/installing/linux/gentoo.md
+++ b/src/wiki/installing/linux/gentoo.md
@@ -5,6 +5,18 @@ eleventyNavigation:
 --- 
 ### <img src="https://www.gentoo.org/assets/img/logo/gentoo-signet.svg" height="20" /> Gentoo
 
-Gentoo ebuilds are available in the [polymc-gentoo](https://gitlab.com/flowln/polymc-gentoo) overlay, named `games-action/polymc`. If you encounter any problems with those, please open an issue on that repository first, since it is maintained by third-parties!
+Ebuilds are available in the official Gentoo repository, under [`games-action/polymc`](https://packages.gentoo.org/packages/games-action/polymc). 
+Note that, for the time being, it is not stabilized, so it's masked for `~amd64` only.
 
-More information, such as installation instructions, and USE flag usage, is [laid out in the README](https://gitlab.com/flowln/polymc-gentoo/-/blob/main/README.md). Have fun! :)
+```bash
+sudo emaint sync -a
+
+# If you need to unmask the package, and considering `package.accept_keywords` to be a folder.
+echo ">=games-action/polymc-1.1.1" | sudo tee -a /etc/portage/package.accept_keywords/polymc
+# Or do this if you want to build from the latest commit instead of a release
+echo "=games-action/polymc-9999 **" | sudo tee -a /etc/portage/package.accept_keywords/polymc
+
+emerge games-action/polymc
+```
+
+Old ebuilds, as well as additional information, can be found [in the old polymc overlay repository](https://gitlab.com/flowln/polymc-gentoo/). Have fun! :)


### PR DESCRIPTION
We're now on [the official Gentoo repo](https://github.com/gentoo/gentoo/commit/0fa539b364d9e3fca1d9fdf2a164e413afb1cb43)! :tada: 

This updates the Gentoo page to point to the new package location.

(sorry for the force-pushes, i am dumb ;-; )