### PR TITLE
portable binary install location + clarity in ubuntu.md

### DIFF
--- a/src/wiki/development/build-instructions.md
+++ b/src/wiki/development/build-instructions.md
@@ -51,7 +51,7 @@ cmake -S . -B build \
 # build
 cd build
 make -j$(nproc) install
-cmake --install . --prefix install --component portable
+cmake --install . --prefix ../install --component portable
 ```
 
 ### Building & installing to the system

--- a/src/wiki/installing/linux/ubuntu.md
+++ b/src/wiki/installing/linux/ubuntu.md
@@ -11,7 +11,7 @@ Several MPR packages are available:
 [![polymc](https://img.shields.io/badge/mpr-polymc-orange)](https://mpr.makedeb.org/packages/polymc)  
 [![polymc-bin](https://img.shields.io/badge/mpr-polymc--bin-orange)](https://mpr.makedeb.org/packages/polymc-bin)  
     
-Installing una a makedeb helper
+Installing una, a makedeb helper
 
 ```
 bash <(curl -fsL https://github.com/AFK-OS/una/raw/main/install.sh)

--- a/src/wiki/installing/linux/ubuntu.md
+++ b/src/wiki/installing/linux/ubuntu.md
@@ -11,7 +11,7 @@ Several MPR packages are available:
 [![polymc](https://img.shields.io/badge/mpr-polymc-orange)](https://mpr.makedeb.org/packages/polymc)  
 [![polymc-bin](https://img.shields.io/badge/mpr-polymc--bin-orange)](https://mpr.makedeb.org/packages/polymc-bin)  
     
-Installing una, a makedeb helper
+Installing Una, a makedeb helper
 
 ```
 bash <(curl -fsL https://github.com/AFK-OS/una/raw/main/install.sh)


### PR DESCRIPTION
If you run `cmake --install . --prefix install --component portable`  in the build directory, it creates an install directory
PolyMC/build/install and places the PolyMC binary and portable.txt file inside. The bin/ and share/ directories are located in
PolyMC/install/, which is where the PolyMC binary and portable.txt should be, hence:
`cmake --install . --prefix ../install --component portable`

Additionally, adding a comma and capitalizing "una" on [the Ubuntu/Debian install page](https://polymc.org/wiki/installing/linux/ubuntu/) makes it easier to read.