### PR TITLE
Generate `appcast.xml` for Sparkle updater

### DIFF
--- a/src/_data/metadata.json
+++ b/src/_data/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "PolyMC",
   "url": "https://polymc.org/",
-  "githubEdit": "https://github.com/PolyMC/polymc.github.io/blob/master/", 
+  "githubEdit": "https://github.com/PolyMC/polymc.github.io/blob/master/",
   "language": "en",
   "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
   "feed": {
@@ -13,6 +13,10 @@
   "jsonfeed": {
     "path": "/feed/feed.json",
     "url": "https://polymc.org/feed/feed.json"
+  },
+  "appcast": {
+    "path": "/feed/appcast.xml",
+    "url": "https://polymc.org/feed/appcast.xml"
   },
   "author": {
     "name": "PolyMC",

--- a/src/feed/appcast.njk
+++ b/src/feed/appcast.njk
@@ -1,0 +1,69 @@
+---
+# Metadata comes from _data/metadata.json
+permalink: "{{ metadata.appcast.path }}"
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ metadata.title }}</title>
+    {% set absoluteUrl %}{{ metadata.appcast.path | url | absoluteUrl(metadata.url) }}{% endset %}
+    <link>{{ absoluteUrl }}</link>
+    <language>en</language>
+    {%- for post in collections.posts | reverse %}
+    {%- if post.data.release_version and post.data.mac_signature %}
+    {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
+      <item>
+        <title>{{ post.data.title }} (macOS)</title>
+        <link>{{ absolutePostUrl }}</link>
+        <sparkle:version>{{ post.data.release_version }}</sparkle:version>
+        <description>
+            {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}
+        </description>
+        <pubDate>{{ post.date | dateToRfc3339 }}</pubDate>
+        {% if post.data.minimum_macos_version %}<sparkle:minimumSystemVersion>{{ post.data.minimum_macos_version }}</sparkle:minimumSystemVersion>{% endif %}
+        {% if post.data.critical_update %}<sparkle:criticalUpdate></sparkle:criticalUpdate>{% endif %}
+        {% if post.data.minimum_autoupdate_version %}<sparkle:minimumAutoupdateVersion>{{ post.data.minimum_autoupdate_version }}</sparkle:minimumAutoupdateVersion>{% endif %}
+        {% if post.data.phased_rollout_interval %}<sparkle:phasedRolloutInterval>{{ post.data.phased_rollout_interval }}</sparkle:phasedRolloutInterval>{% endif %}
+        {%- if post.data.mac_signature %}
+        <enclosure sparkle:os="macos"
+            url="https://github.com/PolyMC/PolyMC/releases/download/{{ post.data.release_version }}/PolyMC-macOS-{{ post.data.release_version }}.tar.gz"
+            length="0"
+            type="application/octet-stream"
+            sparkle:edSignature="{{ post.data.mac_signature }}"/>
+        {%- endif %}
+      </item>
+    {%- endif %}
+    {%- if post.data.release_version and post.data.win32_signature and post.data.win64_signature %}
+    {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
+      <item>
+        <title>{{ post.data.title }} (Windows)</title>
+        <link>{{ absolutePostUrl }}</link>
+        <sparkle:version>{{ post.data.release_version }}</sparkle:version>
+        <description>
+            {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}
+        </description>
+        <pubDate>{{ post.date | dateToRfc3339 }}</pubDate>
+        {% if post.data.minimum_windows_version %}<sparkle:minimumSystemVersion>{{ post.data.minimum_windows_version }}</sparkle:minimumSystemVersion>{% endif %}
+        {% if post.data.critical_update %}<sparkle:criticalUpdate></sparkle:criticalUpdate>{% endif %}
+        {% if post.data.minimum_autoupdate_version %}<sparkle:minimumAutoupdateVersion>{{ post.data.minimum_autoupdate_version }}</sparkle:minimumAutoupdateVersion>{% endif %}
+        {% if post.data.phased_rollout_interval %}<sparkle:phasedRolloutInterval>{{ post.data.phased_rollout_interval }}</sparkle:phasedRolloutInterval>{% endif %}
+        {%- if post.data.win32_signature %}
+        <enclosure sparkle:os="windows-x86"
+            url="https://github.com/PolyMC/PolyMC/releases/download/{{ post.data.release_version }}/PolyMC-Windows-i686-Setup-{{ post.data.release_version }}.zip"
+            length="0"
+            type="application/octet-stream"
+            sparkle:dsaSignature="{{ post.data.win32_signature }}"/>
+        {%- endif %}
+        {%- if post.data.win64_signature %}
+        <enclosure sparkle:os="windows-x64"
+            url="https://github.com/PolyMC/PolyMC/releases/download/{{ post.data.release_version }}/PolyMC-Windows-x86_64-Setup-{{ post.data.release_version }}.zip"
+            length="0"
+            type="application/octet-stream"
+            sparkle:dsaSignature="{{ post.data.win64_signature }}"/>
+        {%- endif %}
+      </item>
+    {%- endif %}
+    {%- endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
Generate and update an `appcast.xml` when release news is posted. Related to https://github.com/PolyMC/PolyMC/pull/479. The appcast will be available at https://polymc.org/feed/appcast.xml.

Information is pulled from data (I don't know what they're called lol) at the top of release notes. Example:

```
---
title: Release 9.9.9
description: Hello world
date: 2023-01-18
release_version: 9.9.9
minimum_macos_version: 10.14.0
mac_signature: VjHIfxB/vb5gwGbqYB58NFOrsXk9Sd43b7Y5UC5MLTHB62Igco7ae47dth6IhvcQj0nMu/o2g3bTomfY49BODA==
critical_update: true
phased_rollout_interval: 86400
minimum_autoupdate_version: 9.0.0
tags:
  - release
---
```

## New Data

These should not be set on posts that are unrelated to releases (i.e., no changes to those). These only apply when posting release notes. (There's no need to go back and add these to old release notes, don't worry.)

### Required

- `release_version`: The version being released (ex: `1.3.0`)
- `mac_signature`: The ed25519 signature for the macOS `.tar.gz` release (see https://github.com/PolyMC/PolyMC/pull/479 for details about how to use `openssl` to generate this manually. GHA should also be able to generate it automatically.)
- `win32_signature` (not required until WinSparkle is implemented): The DSA signature for the Windows 32-bit installer
- `win64_signature` (not required until WinSparkle is implemented): The DSA signature for the Windows 64-bit installer
- `minimum_macos_version`: The minimum macOS version this version of PolyMC supports, used to decide whether an update should be offered to the user or not (actually this isn't strictly required, but highly recommended)
- `minimum_windows_version` (not required until WinSparkle is implemented): Like above, but for Windows

### Optional

If any of these do not apply, do not include them. To my knowledge, most (all?) of these do not currently work with WinSparkle, unfortunately.

- `critical_update`: If set, then the update is marked as critical and the user won't have a skip this update button. Useful if the update is security-related.
- `phased_rollout_interval`: An amount of time, in seconds, that a new group should be offered the update. Users are randomly split into 7 groups (this is hard-coded, we can't change the number of groups), and a new group will get the update every time this number of seconds passes. For example, if set to 86400 (1 day), then in a week, all users will be offered the update. Useful for major updates that are likely to break things. (A user can always manually check for updates if they want the newest update now.)
- `minimum_autoupdate_version`: The minimum "old" version of PolyMC needed for the launcher to automatically update to the new version, if auto updates were enabled by the user. Manual updates (i.e. clicking "update") will always be possible.

---

## Misc notes about the code

- I use separate `<item>`s for Mac and Windows because `<sparkle:minimumSystemVersion>` must be in the item, not the enclosure, and unfortunately this seems to be the only way to be able to set a separate system version for macOS and Windows.
- The `<description>` apparently does not need to be wrapped in `<![CDATA[ ... ]]>` since the HTML is already escaped.
- After doing some more testing, apparently I can set `length="0"` in the enclosure, then you don't need to give it the size of the downloaded file. I decided to do this to avoid having to add even more data to each release, though you can still include it if you want (would require some changes to this code).