### PR TITLE
Copy changes from GitHub release notes to RSS feed items

### DIFF
--- a/src/news/release-1.2.1.md
+++ b/src/news/release-1.2.1.md
@@ -14,8 +14,6 @@ Also check our friends' launch of the Quilt Beta over at [quiltmc.org](https://q
 - Specify build platform for about page by @DioEgizio in #449
 - [macOS] Enable hardened runtime by @kthchew in #454
 
-### Changed
-
 ### Fixed
 - Fix typos and capitalization by @kthchew in #442
 - Fix placeholder translations for mod downloader by @flowln in #443

--- a/src/news/release-1.2.2.md
+++ b/src/news/release-1.2.2.md
@@ -12,17 +12,11 @@ Thanks to everyone who collaborated on this solution in our community channels.
 
 ## Changelog
 
-### Added
-
-### Changed
-
 ### Fixed
 - Hide sensitive tokens from logs by @Scrumplex in #475
 - Implemented a workaround to allow Mojang logins by @TheCodex6824 in #482
 - Move to new CurseForge Core API by @ryanccn in #530
 - [Linux] Fix AppImage scaling issues by @DioEgizio in #492
-
-### Removed
 
 **Full Changelog**: https://github.com/PolyMC/PolyMC/compare/1.2.1...1.2.2
 

--- a/src/news/release-1.3.0.md
+++ b/src/news/release-1.3.0.md
@@ -62,7 +62,6 @@ Initially this release should have included a workaround for download issues wit
 - Remove self-promotion from game client to reduce fingerprinting by @jamierocks in #606
 - [macOS] Remove old macOS migration code by @kthchew in #489
 
-
 **Full Changelog**: https://github.com/PolyMC/PolyMC/compare/1.2.2...1.3.0
 
 You can [grab the latest download here](/download) for your respective platform.

--- a/src/news/release-1.3.1.md
+++ b/src/news/release-1.3.1.md
@@ -20,7 +20,7 @@ Please make sure to download all those mods, otherwise you won't have the full m
 
 ### Changed
 - Clarify T&C for API keys by @Scrumplex in #659
-- Improve download speed when using the CurseForge API by @timoreo in #611
+- Improve download speed when using the CurseForge API by @timoreo22 in #611
 - Improve whitelisted hosts filtering code by @LennyMcLennington in #661
 - Make JVM arguments text-field multi-line by @ryanccn in #624
 - Remove CurseForge API workaround on modpacks by @Scrumplex in #645


### PR DESCRIPTION
I tried to see how eleventy does IDs on feed items but wasn't able to find it. The feed itself seems to have <id> tags so I hope feed readers don't bork with these changes.