### PR TITLE
Typo fix (it's -> its)

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -50,7 +50,7 @@ hero:
         <div class="subtitle">
           <p>Did your settings ever reset after launching an older version? Did you ever accidentally break a world because you opened it in an old version?
           Are you tired of manually switching mods for different versions, installing modloaders?<p>
-          <p>PolyMC can help. Each Minecraft instance has it's own folder, with separate mods, resourcepacks and other things.</p>
+          <p>PolyMC can help. Each Minecraft instance has its own folder, with separate mods, resourcepacks and other things.</p>
         </div>
         <br>
       </div>


### PR DESCRIPTION
The possessive form of "it" is "its", rather than "it's" (which is the conjunction of "it is")