### PR TITLE
Make footer text color white

### DIFF
--- a/src/_includes/index.css
+++ b/src/_includes/index.css
@@ -361,6 +361,7 @@ a.direct-link:focus:visited,
 .footer {
   text-align: center;
   padding: 2em;
+  color: #fff;
 }
 
 


### PR DESCRIPTION
With the black text, the footer is nearly unreadable (except the link). This PR makes it white, just like the color of the hero part.

![image](https://user-images.githubusercontent.com/11584103/189407769-309d94a7-370f-429c-be0a-b613670bad4f.png)
