### PR TITLE
Remove Flathub from dead repos

### DIFF
--- a/src/news/what-happened.md
+++ b/src/news/what-happened.md
@@ -12,7 +12,7 @@ and update servers. However, these remain safe to users, and we're dedicated to 
 
 # How can I get updates to PolyMC going forward?
 
-The following platforms (repositories) are unable to receive updates as of now along with a few others that are not listed, these are: Flathub, AUR, COPR, Scoop, and Gentoo.
+The following platforms (repositories) are unable to receive updates as of now along with a few others that are not listed, these are: AUR, COPR, Scoop, and Gentoo.
 
 To get the latest updates to the software please consult the Github releases page (Found at https://github.com/PolyMC/PolyMC/releases).
 If you were on Scoop, the best option currently is to switch to the Windows installer, which can be found at the Github releases page for PolyMC.


### PR DESCRIPTION
We’ve gained control of flathub and the software is now available on that platform.
This should be considered an important change to keep information accurate. Please merge ASAP.